### PR TITLE
Change to platform prefered directory separator

### DIFF
--- a/src/UnionCloud/Api.php
+++ b/src/UnionCloud/Api.php
@@ -31,7 +31,7 @@ class Api {
         
         // verify ssl certs incase server misconfigured
         $guzzleClient = new GuzzleClient(array(
-            "verify" => dirname(__FILE__, 3) . "\unioncloud.pem"
+            "verify" => dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . "unioncloud.pem"
         ));
         $this->client->setClient($guzzleClient);
         


### PR DESCRIPTION
Fixes an issue I encountered with the certificate authority bundle not being found by PHP on macOS. By using the PHP constant this should work on all platforms now.